### PR TITLE
Update New-SQLTable.ps1

### DIFF
--- a/public/New-SQLTable.ps1
+++ b/public/New-SQLTable.ps1
@@ -1,86 +1,94 @@
-﻿function New-SQLTable {
+function New-SQLTable {
     <#
-    
         .SYNOPSIS
-        
+        Creates a new SQL Server table.
+
         .DESCRIPTION
-        
-        .PARAMETER filepath
-    
+        This function connects to a SQL Server database and creates a table
+        with the specified columns, schema, and database.
+
+        .PARAMETER Table
+        The name of the table to create.
+
+        .PARAMETER Schema
+        The schema to create the table in. Default is "dbo".
+
+        .PARAMETER Database
+        The target database.
+
+        .PARAMETER Server
+        The SQL Server instance name (only required if no connection is passed).
+
+        .PARAMETER Connection
+        An existing SQL connection object.
+
+        .PARAMETER Columns
+        Hashtable of column definitions, e.g. @{ Id = "INT PRIMARY KEY"; Name = "NVARCHAR(100)" }
+
         .EXAMPLE
-    
+        New-SQLTable -Database "TestDB" -Server "localhost" -Table "Employees" -Columns @{ Id = "INT PRIMARY KEY"; Name = "NVARCHAR(50)" }
     #>
     [CmdletBinding(DefaultParameterSetName = 'CreateConn')]
     param(
-        [Parameter(Mandatory, ParameterSetName='CreateConn', position=0, ValueFromPipeline)]
-        [Parameter(Mandatory, ParameterSetName='PassedConn', position=0, ValueFromPipeline)]
-        [hashtable]$InsertObject,
-        [Parameter(ParameterSetName='CreateConn')]
-        [Parameter(ParameterSetName='PassedConn')]
-        [String]$Table = "master",
-        [Parameter(ParameterSetName='CreateConn')]
-        [Parameter(ParameterSetName='PassedConn')]
+        [Parameter(Mandatory, Position=0)]
+        [String]$Table,
+
+        [Parameter(Position=1)]
         [String]$Schema = "dbo",
-        [Parameter(Mandatory, ParameterSetName='CreateConn', position=2)]
-        [Parameter(Mandatory, ParameterSetName='PassedConn', position=2)]
+
+        [Parameter(Mandatory, Position=2)]
         [String]$Database,
-        [Parameter(Mandatory, ParameterSetName='CreateConn', position=3)]
+
+        [Parameter(ParameterSetName='CreateConn', Mandatory, Position=3)]
         [String]$Server,
-        [Parameter(Mandatory, ParameterSetName='PassedConn', position=3)]
-        [System.Data.SqlClient.SqlConnection]$Connection = $null
+
+        [Parameter(ParameterSetName='PassedConn', Mandatory, Position=3)]
+        [System.Data.SqlClient.SqlConnection]$Connection,
+
+        [Parameter(Mandatory, Position=4)]
+        [Hashtable]$Columns
     )
-    <#param(
-        [Parameter(Mandatory=$true, position=0)]
-        [String]$database = "",
-        [Parameter(Mandatory=$true, position=1)]
-        [String]$table,
-        [Parameter(Mandatory=$true, position=2)]
-        [Hashtable]$columns = @{},
-        [Parameter(Mandatory=$false, position=3)]
-        [String]$server,
-        [Parameter(Mandatory=$false, position=4)]
-        [String]$schema = "dbo",
-        [Parameter(Mandatory=$false, ValueFromPipeline)]
-        [System.Data.SqlClient.SqlConnection]$conn = $null
-    )#>
 
-    ############# INITIALIZE OBJECTS ######################################
-    if ($conn -eq $null){
-        $conn = New-Object System.Data.SqlClient.SqlConnection
-        $conn.ConnectionString = "Server = $server; Database = $database; Integrated Security = True"
-        try{
-            $conn.open()
-        } catch [System.Data.SqlClient.SqlException]{
-            write-error "database not accessible to user account"
-            break
+    ############# INITIALIZE CONNECTION ##################################
+    if (-not $PSBoundParameters.ContainsKey('Connection')) {
+        $Connection = New-Object System.Data.SqlClient.SqlConnection
+        $Connection.ConnectionString = "Server=$Server; Database=$Database; Integrated Security=True"
+
+        try {
+            $Connection.Open()
+        }
+        catch {
+            Write-Error "Failed to connect to SQL Server instance [$Server], database [$Database]. Error: $_"
+            return
         }
     }
-    
-    if ($conn.State -ne "Open"){
-        $conn.Open()
+    elseif ($Connection.State -ne "Open") {
+        $Connection.Open()
     }
-    
-    $query = New-Object System.Data.SqlClient.SqlCommand
-    $query.connection = $conn
-    
-    #######################################################################
+    ######################################################################
 
-    $count = 1
-    $columnsFormatted = "("
-    $columns.Keys | %{
-        $columnsFormatted += ((ConvertTo-SQLColumnName $_) + " " + $columns[$_])
-        if ($count -ne $columns.count){
-            $columnsFormatted += ", "
+    try {
+        # Format columns
+        $columnsFormatted = $Columns.Keys | ForEach-Object {
+            "[" + $_ + "] " + $Columns[$_]
+        } -join ", "
+
+        $queryString = "CREATE TABLE [$Schema].[$Table] ($columnsFormatted);"
+
+        Write-Verbose "Executing query: $queryString"
+
+        $command = $Connection.CreateCommand()
+        $command.CommandText = $queryString
+        $command.ExecuteNonQuery()
+
+        Write-Host "Table [$Schema].[$Table] created successfully in database [$Database]."
+    }
+    catch {
+        Write-Error "Failed to create table [$Schema].[$Table]. Error: $_"
+    }
+    finally {
+        if ($Connection.State -eq "Open" -and -not $PSBoundParameters.ContainsKey('Connection')) {
+            $Connection.Close()
         }
-        $count += 1
     }
-    $columnsFormatted += ")"
-
-    $queryString = "CREATE TABLE [$database].[$schema].[$table] $columnsFormatted;"
-    $query.CommandText = $queryString
-    Write-Verbose $queryString
-
-    $query.ExecuteNonQuery()
-
-    $conn.close()
 }


### PR DESCRIPTION
In this revision, I cleaned up the function to make it more consistent and reliable. The unused `$InsertObject` parameter was removed, and `$columns`, which was previously referenced but not defined, has been explicitly added as a required parameter. Connection handling was improved so that if an existing connection is passed in, the function won’t close it, but if the function creates the connection itself, it will close it properly at the end. I also added more robust error handling with clear messages for both connection and query failures. Column definitions are now formatted more safely by enclosing column names in brackets, and parameter naming has been made more consistent with PowerShell conventions. Finally, the function outputs a confirmation message when the table is created successfully and provides verbose output of the executed SQL command for easier debugging.